### PR TITLE
Refactor types

### DIFF
--- a/src/components/BreadCrumbs.tsx
+++ b/src/components/BreadCrumbs.tsx
@@ -1,11 +1,10 @@
 import React from "react"
-import { AlbumListItem } from "../data/types"
 import { Link } from "react-router-dom"
 import homeIcon from "../assets/icon-color.png"
-import { BaseProps } from "../data/types"
+import { BaseProps, BreadcrumbItem } from "../data/types"
 
 interface BreadcrumbsProps extends BaseProps {
-  breadcrumbs: AlbumListItem[]
+  breadcrumbs: BreadcrumbItem[]
   bg?: boolean
 }
 

--- a/src/data/album.ts
+++ b/src/data/album.ts
@@ -1,11 +1,11 @@
 import axios from "axios"
 import { useQuery } from "react-query"
-import { APIError, AlbumDetailData, AlbumListData, fetchAlbumsParams } from "./types"
+import { APIError, AlbumDetailData, AlbumListData, FetchAlbumsParams } from "./types"
 
 function album() {
   const baseUrl = process.env.REACT_APP_API_BASE_URL
 
-  const fetchAlbums = async (params: fetchAlbumsParams) => {
+  const fetchAlbums = async (params: FetchAlbumsParams) => {
     const res = await axios({
       url: `${baseUrl}/api/v1/albums`,
       params: params,
@@ -23,7 +23,7 @@ function album() {
     return query
   }
 
-  const albumsQuery = (params: fetchAlbumsParams) => {
+  const albumsQuery = (params: FetchAlbumsParams) => {
     const query = useQuery<AlbumListData, APIError>(
       ["albums", params.limit, params.parent],
       () => fetchAlbums(params),

--- a/src/data/photo.ts
+++ b/src/data/photo.ts
@@ -1,7 +1,7 @@
 import React from "react"
 import {
   APIError,
-  fetchPhotosParams,
+  FetchPhotosParams,
   PhotoListData,
   FetchPhotoInAlbumParams,
   PhotoData,
@@ -19,7 +19,7 @@ function photo() {
     }).then((res) => res.data)
   }
 
-  function fetchPhotos(params: fetchPhotosParams) {
+  function fetchPhotos(params: FetchPhotosParams) {
     return axios({
       url: `${baseUrl}/api/v1/photos`,
       params: params,
@@ -35,7 +35,7 @@ function photo() {
     })
   }
 
-  const photosQuery = ({ album, limit, offset }: fetchPhotosParams) => {
+  const photosQuery = ({ album, limit, offset }: FetchPhotosParams) => {
     const query = useInfiniteQuery<PhotoListData, APIError>(
       ["photos", album, limit, offset],
       ({ pageParam }) => fetchPhotos({ album, limit, offset: pageParam }),

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -52,13 +52,13 @@ export type FetchPhotoInAlbumParams = {
   photoId: string
 }
 
-export type fetchPhotosParams = {
+export type FetchPhotosParams = {
   album?: string
   limit: number
   offset?: number
 }
 
-export interface fetchAlbumsParams {
+export interface FetchAlbumsParams {
   limit: number
   parent?: string
 }

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -5,6 +5,13 @@ export interface ListData<T> {
   total: number
   results: T[]
 }
+
+export interface BreadcrumbItem {
+  id: string
+  title: string
+  date: string
+}
+
 export interface PhotoListItem {
   id: string
   filename: string
@@ -24,11 +31,7 @@ export interface AlbumDetailItem {
   title: string
   date: string
   description: string
-  breadcrumbs: {
-    id: string
-    title: string
-    date: string
-  }[]
+  breadcrumbs: BreadcrumbItem[]
 }
 
 export type PhotoId = string | undefined


### PR DESCRIPTION
Just a cleanup of types.

- Types should always be capitalized.
- Breadcrumbs don't have a thumbnail, I'm introducing `BreadcrumbItem` type to differentiate.